### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Continous Integration
 
 on: pull_request
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nikmaxott/curriculum-vitae/security/code-scanning/2](https://github.com/nikmaxott/curriculum-vitae/security/code-scanning/2)

The best way to fix this issue is to explicitly set the permissions for the GITHUB_TOKEN used in the workflow. For CI tasks that only require reading code (such as running tests or linting), set `contents: read` at the workflow level or the job level.  
- You should edit `.github/workflows/ci.yml` to add a root-level `permissions:` key, immediately after the workflow `name` or `on:` section.  
- The block should specify `contents: read` as the minimal necessary permission.  
- No changes or imports are required elsewhere, and there is no effect on the core CI functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
